### PR TITLE
provide fallback for window.matchMedia

### DIFF
--- a/src/JSONView.vue
+++ b/src/JSONView.vue
@@ -12,7 +12,7 @@
 import Vue, { VueConstructor } from 'vue';
 import JSONViewItem from './JSONViewItem.vue';
 
-const isDarkMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+const isDarkMediaQuery = window && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)')
   .matches;
 
 export default Vue.extend({


### PR DESCRIPTION
window.matchMedia does not exist in some environments (including jsdom). should fall back to light mode if matchMedia is not available instead of throwing an exception.